### PR TITLE
Fix invalid line in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,3 @@ paragraph=Very small command line manager
 category=Uncategorized
 url=
 architectures=*
-å


### PR DESCRIPTION
Each line in library.properties must either contain an '=', start with a #, or be whitespace. Installation of a library with an invalid line will cause compilation of any code (even if it doesn't #include the library) to fail:
```
Error reading file (E:\arduino\libraries\tinycmdtable\library.properties:9): Invalid line format, should be 'key=value'
```
Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

This issue might block inclusion in the Arduino Library Manager index (https://github.com/arduino/Arduino/issues/8521).